### PR TITLE
MapSet: Add support for maps comparisons using slider & map set tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "node-cache": "^5.1.2",
         "openid-client": "^5.7.1",
         "react": "^19.0.0",
+        "react-compare-slider": "^3.1.0",
         "react-dom": "^19.0.0",
         "react-resize-detector": "^12.0.2",
         "sqlite": "^5.1.1",
@@ -9375,6 +9376,20 @@
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-compare-slider": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-compare-slider/-/react-compare-slider-3.1.0.tgz",
+      "integrity": "sha512-TQVbZYmYyTIeKRmQciVXCmUwHjTThQTON7GfWfzMAOInRRG9tCiQnVXnCUd5DJ5l3Hngh4IEzOb9TG82gjoEhQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "node-cache": "^5.1.2",
     "openid-client": "^5.7.1",
     "react": "^19.0.0",
+    "react-compare-slider": "^3.1.0",
     "react-dom": "^19.0.0",
     "react-resize-detector": "^12.0.2",
     "sqlite": "^5.1.1",

--- a/src/client/map/MapSet/MapSet.css
+++ b/src/client/map/MapSet/MapSet.css
@@ -8,7 +8,7 @@
 	container-type: size;
 }
 
-/* Map set grid used for displaying maps in a grid layout */
+/* --- Map set grid used for displaying maps in a grid layout --- */
 .ptr-MapSet-grid {
 	width: 100%;
 	height: 100%;
@@ -50,6 +50,26 @@
 		display: grid;
 		grid-template-columns: repeat(2, 1fr);
 	}
+}
+
+/* --- Map set slider used for comparing of two maps --- */
+.ptr-MapSetSliderComparator {
+	width: 100%;
+	height: 100%;
+}
+
+.ptr-MapSetSliderComparator .ptr-MapSet-map {
+	width: 100%;
+	height: 100%;
+}
+
+
+button[data-rcs='handle-container'] {
+	z-index: 29;
+}
+
+div[data-rcs='clip-item'] {
+	z-index: 28;
 }
 
 /* Map set map used for displaying individual maps */

--- a/src/client/map/MapSet/MapSet.tsx
+++ b/src/client/map/MapSet/MapSet.tsx
@@ -1,49 +1,138 @@
 import classnames from 'classnames';
 import React from 'react';
+import { ReactCompareSlider, ReactCompareSliderHandle } from 'react-compare-slider';
 import { SingleMap } from '../MapSet/SingleMap';
 import useSharedState from '../../shared/hooks/state.useSharedState';
 import { getMapSetByKey } from '../../shared/appState/selectors/getMapSetByKey';
 import { getSyncedView } from '../../shared/appState/selectors/getSyncedView';
 import './MapSet.css';
 
+/**
+ * Props for the MapSetWrapper component.
+ * @interface MapSetWrapperProps
+ * @property {React.ReactNode} [children] - The child elements to be wrapped.
+ */
+export interface MapSetWrapperProps {
+	children?: React.ReactNode;
+}
+
+/**
+ * A wrapper component for the MapSet. Adds a consistent outer div with a specific class.
+ * @param {MapSetWrapperProps} props - The props for the wrapper component.
+ * @returns {JSX.Element} The wrapped children inside a div with the "ptr-MapSet" class.
+ */
+export const MapSetWrapper = ({ children }: MapSetWrapperProps) => {
+	return <div className="ptr-MapSet">{children}</div>;
+};
+
+/**
+ * Props for the MapSet component.
+ * @interface MapSetProps
+ * @property {string} sharedStateKey - The key used to retrieve the map set from the shared state.
+ * @property {React.ElementType} [SingleMapTools] - Optional tools component to render alongside each map.
+ * @property {React.ElementType} [MapSetTools] - Optional tools component to render for the entire map set.
+ */
 export interface MapSetProps {
-	// map set identifier
 	sharedStateKey: string;
 	SingleMapTools?: React.ElementType;
+	MapSetTools?: React.ElementType;
 }
+
 /**
- * MapSet component
- *
- * This component renders a set of maps (with either synced, or unsynced view) based on the shared state key.
- * It uses the SingleMap component to render each individual map.
- *
- * @param {MapSetProps} props - The properties for the MapSet component.
- * @returns {JSX.Element | null} The rendered MapSet component or null if no map set is found.
+ * MapSet component renders a set of maps in either a grid or slider mode based on the shared state.
+ * Handles synced zoom and center for maps and provides warnings for invalid configurations.
+ * @param {MapSetProps} props - The props for the MapSet component.
+ * @returns {JSX.Element | null} The rendered MapSet or null if no maps are found.
  */
-export const MapSet = ({ sharedStateKey, SingleMapTools }: MapSetProps) => {
+export const MapSet = ({ sharedStateKey, SingleMapTools, MapSetTools }: MapSetProps) => {
+	// Retrieve shared state and map set using the provided key
 	const [sharedState] = useSharedState();
 	const mapSet = getMapSetByKey(sharedState, sharedStateKey);
-	const numberOfMaps = mapSet?.maps?.length;
+	const maps = mapSet?.maps;
 
-	if (numberOfMaps) {
-		const syncedView = getSyncedView(sharedState, sharedStateKey);
-		const gridClasses = classnames('ptr-MapSet-grid', `has-${numberOfMaps}-maps`);
-
-		return (
-			<div className="ptr-MapSet">
-				<div className={gridClasses}>
-					{mapSet.maps.map((mapKey: string) => {
-						return (
-							<div key={mapKey} className="ptr-MapSet-map">
-								<SingleMap mapKey={mapKey} syncedView={syncedView} />
-								{SingleMapTools && React.createElement(SingleMapTools, { mapKey, mapSetKey: sharedStateKey })}
-							</div>
-						);
-					})}
-				</div>
-			</div>
-		);
-	} else {
+	// Return null and log a warning if the map set or maps are not found
+	if (!mapSet || !maps?.length) {
+		console.warn(`MapSet with key "${sharedStateKey}" not found or has no maps.`);
 		return null;
 	}
+
+	// Extract map set properties
+	const numberOfMaps = maps.length;
+	const mode = mapSet.mode ?? 'grid';
+	const hasSyncedZoomAndCenter = mapSet.sync && (mapSet.sync.zoom || mapSet.sync.center);
+
+	// Memoize the synced view for performance optimization
+	const syncedView = getSyncedView(sharedState, sharedStateKey);
+
+	// Generate CSS classes for the grid layout based on the number of maps
+	const gridClasses = classnames('ptr-MapSet-grid', `has-${numberOfMaps}-maps`);
+
+	// Render slider mode if requirements are met
+	if (mode === 'slider' && numberOfMaps === 2 && hasSyncedZoomAndCenter) {
+		return (
+			<MapSetWrapper>
+				<ReactCompareSlider
+					onlyHandleDraggable
+					handle={<ReactCompareSliderHandle />}
+					className="ptr-MapSetSliderComparator"
+					itemOne={
+						<div key={maps[0]} className="ptr-MapSet-map">
+							{/* Render individual map */}
+							<SingleMap mapKey={maps[0]} syncedView={syncedView} />
+							{/* Optionally render tools for the map */}
+							{SingleMapTools &&
+								React.createElement(SingleMapTools, {
+									mapKey: maps[0],
+									mapSetKey: sharedStateKey,
+									isSliderModeLeftMap: true,
+								})}
+						</div>
+					}
+					itemTwo={
+						<div key={maps[1]} className="ptr-MapSet-map">
+							{/* Render individual map */}
+							<SingleMap mapKey={maps[1]} syncedView={syncedView} />
+							{/* Optionally render tools for the map */}
+							{SingleMapTools &&
+								React.createElement(SingleMapTools, {
+									mapKey: maps[1],
+									mapSetKey: sharedStateKey,
+									isSliderModeRightMap: true,
+								})}
+						</div>
+					}
+				></ReactCompareSlider>
+				{MapSetTools && React.createElement(MapSetTools, { mapSetKey: sharedStateKey })}
+			</MapSetWrapper>
+		);
+	}
+
+	// Log warnings if slider mode is requested but requirements are not met
+	if (mode === 'slider') {
+		if (numberOfMaps !== 2) {
+			console.warn(
+				`MapSet with key "${sharedStateKey}" is in slider mode but has ${numberOfMaps} maps. Slider mode requires exactly 2 maps.`
+			);
+		}
+		if (!hasSyncedZoomAndCenter) {
+			console.warn(`MapSet with key "${sharedStateKey}" is in slider mode but does not have synced zoom and center.`);
+		}
+	}
+
+	// Render grid mode for all other cases
+	return (
+		<MapSetWrapper>
+			<div className={gridClasses}>
+				{maps.map((mapKey: string) => (
+					<div key={mapKey} className="ptr-MapSet-map">
+						{/* Render individual map */}
+						<SingleMap mapKey={mapKey} syncedView={syncedView} />
+						{/* Optionally render tools for the map */}
+						{SingleMapTools && React.createElement(SingleMapTools, { mapKey, mapSetKey: sharedStateKey })}
+					</div>
+				))}
+			</div>
+			{MapSetTools && React.createElement(MapSetTools, { mapSetKey: sharedStateKey })}
+		</MapSetWrapper>
+	);
 };

--- a/src/client/shared/appState/enum.state.actionType.ts
+++ b/src/client/shared/appState/enum.state.actionType.ts
@@ -52,4 +52,7 @@ export enum StateActionType {
 
 	/** Action to toggle or change map set synchronization. */
 	MAP_SET_SYNC_CHANGE = 'mapSetSyncChange',
+
+	/** Action to change the mode of a map set (e.g., slider, grid). */
+	MAP_SET_MODE_CHANGE = 'mapSetModeChange',
 }

--- a/src/client/shared/appState/reducerHandlers/mapSetModeChange.ts
+++ b/src/client/shared/appState/reducerHandlers/mapSetModeChange.ts
@@ -1,0 +1,36 @@
+import { AppSharedState } from '../../appState/state.models';
+import { ActionMapSetModeChange } from '../../appState/state.models.actions';
+import { getMapSetByKey } from '../selectors/getMapSetByKey';
+import { MapSetModel } from '../../models/models.mapSet';
+
+/**
+ * Handles the action to change the mode of a map set in the shared application state.
+ * Updates the mode of the specified map set and returns the updated state.
+ *
+ * @param {AppSharedState} state - The current shared application state.
+ * @param {ActionMapSetModeChange} action - The action containing the payload with the map set key and new mode.
+ * @returns {AppSharedState} The updated application state with the modified map set mode.
+ * @throws {Error} If the payload is missing or the map set with the specified key is not found.
+ */
+export const reduceHandlerMapSetModeChange = (
+	state: AppSharedState,
+	action: ActionMapSetModeChange
+): AppSharedState => {
+	const { payload } = action;
+
+	// Ensure the payload is provided
+	if (!payload) throw new Error('No payload provided for map set mode change action');
+	const { key: mapSetKey, mode } = payload;
+
+	// Find the map set by key
+	const mapSet = getMapSetByKey(state, mapSetKey);
+	if (!mapSet) throw new Error(`MapSet with key ${mapSetKey} not found`);
+
+	// Update the mode of the map set
+	const updatedMapSets: MapSetModel[] = state.mapSets.map((mapSet: MapSetModel) =>
+		mapSet.key === mapSetKey ? { ...mapSet, mode } : mapSet
+	);
+
+	// Return the updated state
+	return { ...state, mapSets: updatedMapSets };
+};

--- a/src/client/shared/appState/state.models.actions.ts
+++ b/src/client/shared/appState/state.models.actions.ts
@@ -151,6 +151,14 @@ export interface ActionMapSetSyncChange {
 }
 
 /**
+ * Change map set mode
+ */
+export interface ActionMapSetModeChange {
+	type: StateActionType.MAP_SET_MODE_CHANGE;
+	payload: { key: string; mode: 'slider' | 'grid' };
+}
+
+/**
  * One of any of possible actions
  */
 export type OneOfStateActions =
@@ -169,5 +177,6 @@ export type OneOfStateActions =
 	| ActionMapLayerOpacityChange
 	| ActionMapViewChange
 	| ActionMapSetSyncChange
+	| ActionMapSetModeChange
 	| ActionGlobalStateUpdate
 	| ActionApplyPersistentState;

--- a/src/client/shared/appState/state.reducer.ts
+++ b/src/client/shared/appState/state.reducer.ts
@@ -13,6 +13,7 @@ import { reduceHandlerMapLayerOpacityChange } from '../appState/reducerHandlers/
 import { reduceHandlerMapSetAddMap } from '../appState/reducerHandlers/mapSetAddMap';
 import { reduceHandlerMapSetRemoveMap } from '../appState/reducerHandlers/mapSetRemoveMap';
 import { reduceHandlerRemoveMapSetMapsByKeys } from '../appState/reducerHandlers/mapSetRemoveMapsByKeys';
+import { reduceHandlerMapSetModeChange } from '../appState/reducerHandlers/mapSetModeChange';
 
 /**
  * React reducer for shared application state. Use it in useReducer react hook
@@ -84,6 +85,9 @@ export const reducerSharedAppState = (
 
 		case StateActionType.MAP_SET_SYNC_CHANGE:
 			return reduceHandlerMapSetSyncChange(currentState, action);
+
+		case StateActionType.MAP_SET_MODE_CHANGE:
+			return reduceHandlerMapSetModeChange(currentState, action);
 
 		default:
 			throw new Error(`Shared State: Unknown action type "${(action as OneOfStateActions).type}"`);

--- a/src/client/shared/models/models.mapSet.ts
+++ b/src/client/shared/models/models.mapSet.ts
@@ -8,6 +8,7 @@ import { MapSetSync } from '../models/models.mapSetSync';
 export interface MapSetModel {
 	key: string;
 	maps: string[];
+	mode?: 'slider' | 'grid';
 	sync: MapSetSync;
 	view: Partial<MapView>;
 }


### PR DESCRIPTION
This PR introduces a slider mode in map set, which enable to comapare two maps by swiping