### PR TITLE
Allow geojson layer styling

### DIFF
--- a/src/client/map/logic/map.layers.geojson.ts
+++ b/src/client/map/logic/map.layers.geojson.ts
@@ -3,6 +3,15 @@ import { LayerGeneralProps } from './map.layers.models';
 import { validateDatasource } from './validate.layers';
 import { UsedDatasourceLabels } from '../../../globals/shared/panther/enums.panther';
 
+const defaultOptions = {
+	filled: true,
+	stroked: true,
+	pointRadiusScale: 0.2,
+	getPointRadius: 50,
+	getFillColor: [255, 100, 100],
+	getLineColor: [255, 100, 100],
+};
+
 /**
  * Creates a GeoJsonLayer with the specified properties.
  *
@@ -15,15 +24,6 @@ import { UsedDatasourceLabels } from '../../../globals/shared/panther/enums.pant
  */
 export const createGeojsonLayer = ({ sourceNode, isActive, key, opacity }: LayerGeneralProps) => {
 	const { url, configurationJs } = validateDatasource(sourceNode, UsedDatasourceLabels.Geojson, true);
-
-	const defaultOptions = {
-		filled: true,
-		stroked: true,
-		pointRadiusScale: 0.2,
-		getPointRadius: 50,
-		getFillColor: [255, 100, 100],
-		getLineColor: [255, 100, 100],
-	};
 
 	const geojsonOptions = configurationJs?.geojsonOptions ?? defaultOptions;
 


### PR DESCRIPTION
This PR enables custom styling for GeoJSON layers by retrieving optional style configurations from the datasource and applying them, with sensible defaults as a fallback.