### PR TITLE
Upgrade @gisatcz/deckgl-geolib to v2.1.1 and update related dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
 				"@deck.gl/geo-layers": "^9.2.2",
 				"@deck.gl/layers": "^9.2.2",
 				"@deck.gl/react": "^9.2.2",
-				"@gisatcz/deckgl-geolib": "^2.0.0",
+				"@gisatcz/deckgl-geolib": "^2.1.1",
 				"@gisatcz/ptr-be-core": "^0.0.7",
 				"@mantine/core": "^8.0.2",
 				"@mantine/hooks": "^8.0.2",
@@ -372,29 +372,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/@chunkd/source": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/@chunkd/source/-/source-11.1.0.tgz",
-			"integrity": "sha512-3BcrHK4XDm3t4vDx1OisgcOZ05+EarEqwaGVIL7IMHUmkXwN/Aprlnr7aVP3BYcltgcCcfMd1pXQicbSrP563g==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/@chunkd/source-http": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/@chunkd/source-http/-/source-http-11.1.0.tgz",
-			"integrity": "sha512-vKCR/MwFuj7fAglym3BiSYromIFR65K9cIY3Z459B7HQR7aLATxQiQcxTfXNwFy+1/Xooe/6UXHrGs4EKcg6Vw==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@chunkd/source": "^11.1.0"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
 		"node_modules/@csstools/color-helpers": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
@@ -554,22 +531,22 @@
 			}
 		},
 		"node_modules/@deck.gl/geo-layers": {
-			"version": "9.2.5",
-			"resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.2.5.tgz",
-			"integrity": "sha512-QVjLwHEAtNqRdjBuYJwztCAwSTmgWujPT0geGWaFhr7ZvyigAqi3l2ETys5YqjjJ87bKnUBwd6iOyw1xkXbsCw==",
+			"version": "9.2.8",
+			"resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.2.8.tgz",
+			"integrity": "sha512-WEiPbDM6bqXityfFGplsKNTpYKzfUyj/mpnQpaNJ5qJ6Cl2W7SDnP+0K/UisbZ8m8eXYCiiu+ykb4+YwvOFc8g==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@loaders.gl/3d-tiles": "^4.2.0",
-				"@loaders.gl/gis": "^4.2.0",
-				"@loaders.gl/loader-utils": "^4.2.0",
-				"@loaders.gl/mvt": "^4.2.0",
-				"@loaders.gl/schema": "^4.2.0",
-				"@loaders.gl/terrain": "^4.2.0",
-				"@loaders.gl/tiles": "^4.2.0",
-				"@loaders.gl/wms": "^4.2.0",
-				"@luma.gl/gltf": "^9.2.4",
-				"@luma.gl/shadertools": "^9.2.4",
+				"@loaders.gl/3d-tiles": "^4.3.4",
+				"@loaders.gl/gis": "^4.3.4",
+				"@loaders.gl/loader-utils": "^4.3.4",
+				"@loaders.gl/mvt": "^4.3.4",
+				"@loaders.gl/schema": "^4.3.4",
+				"@loaders.gl/terrain": "^4.3.4",
+				"@loaders.gl/tiles": "^4.3.4",
+				"@loaders.gl/wms": "^4.3.4",
+				"@luma.gl/gltf": "^9.2.6",
+				"@luma.gl/shadertools": "^9.2.6",
 				"@math.gl/core": "^4.1.0",
 				"@math.gl/culling": "^4.1.0",
 				"@math.gl/web-mercator": "^4.1.0",
@@ -583,9 +560,9 @@
 				"@deck.gl/extensions": "~9.2.0",
 				"@deck.gl/layers": "~9.2.0",
 				"@deck.gl/mesh-layers": "~9.2.0",
-				"@loaders.gl/core": "^4.2.0",
-				"@luma.gl/core": "~9.2.4",
-				"@luma.gl/engine": "~9.2.4"
+				"@loaders.gl/core": "^4.3.4",
+				"@luma.gl/core": "~9.2.6",
+				"@luma.gl/engine": "~9.2.6"
 			}
 		},
 		"node_modules/@deck.gl/layers": {
@@ -1356,32 +1333,29 @@
 			"peer": true
 		},
 		"node_modules/@gisatcz/deckgl-geolib": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@gisatcz/deckgl-geolib/-/deckgl-geolib-2.0.0.tgz",
-			"integrity": "sha512-9uKF0dFX1j1vqW8oH1TbbzII9hN4BG8pO292NMLAQRtE0Y60mSiwCp8IhChhFJrFImIvCxUjljr7D/yHIxLgvA==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@gisatcz/deckgl-geolib/-/deckgl-geolib-2.1.1.tgz",
+			"integrity": "sha512-zL/iTwGwKKZhrAA4Um/MWJl8HZfzdc6DJu3uuBa8pm8FP/RUYQXDU8YK3zf6yv7El6Ne0hJ2PXP8Rfipr+9bMw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@chunkd/source-http": "^11.1.0",
-				"@deck.gl/core": "^9.0.33",
-				"@deck.gl/extensions": "^9.0.33",
-				"@deck.gl/geo-layers": "^9.0.33",
-				"@deck.gl/layers": "^9.0.33",
-				"@deck.gl/mesh-layers": "^9.0.33",
-				"@deck.gl/react": "^9.0.33",
-				"@deck.gl/widgets": "^9.0.33",
-				"@loaders.gl/loader-utils": "^4.3.1",
-				"@loaders.gl/schema": "^4.3.1",
-				"@luma.gl/constants": "^9.0.27",
 				"@mapbox/martini": "^0.2.0",
-				"@math.gl/web-mercator": "^4.1.0",
 				"chroma-js": "^2.4.2",
-				"geotiff": "^2.1.3",
-				"jpeg-js": "^0.4.4",
-				"pako": "^2.1.0"
+				"geotiff": "^3.0.0"
 			},
 			"engines": {
 				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@deck.gl/core": ">=9.0.0",
+				"@deck.gl/extensions": ">=9.0.0",
+				"@deck.gl/geo-layers": ">=9.0.0",
+				"@deck.gl/layers": ">=9.0.0",
+				"@deck.gl/mesh-layers": ">=9.0.0",
+				"@loaders.gl/core": ">=4.0.0",
+				"@loaders.gl/loader-utils": ">=4.0.0",
+				"@loaders.gl/schema": ">=4.0.0",
+				"@math.gl/web-mercator": ">=4.0.0"
 			}
 		},
 		"node_modules/@gisatcz/ptr-be-core": {
@@ -1966,9 +1940,9 @@
 			"peer": true
 		},
 		"node_modules/@luma.gl/core": {
-			"version": "9.2.5",
-			"resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-9.2.5.tgz",
-			"integrity": "sha512-7tQ6wTTtQV6iWZxjMr+BDzS2o814EvaNW5efKtdzdvbbNyDWkDQZkyHkPvgGBB1o/+N2cbZS7GWyxOljCCH5uA==",
+			"version": "9.2.6",
+			"resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-9.2.6.tgz",
+			"integrity": "sha512-d8KcH8ZZcjDAodSN/G2nueA9YE2X8kMz7Q0OxDGpCww6to1MZXM3Ydate/Jqsb5DDKVgUF6yD6RL8P5jOki9Yw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -1980,9 +1954,9 @@
 			}
 		},
 		"node_modules/@luma.gl/engine": {
-			"version": "9.2.5",
-			"resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-9.2.5.tgz",
-			"integrity": "sha512-swM+4VO+ab4DU58TB+cdSdby/MGLLWA9ez6BmaZ0HZwLN1HNdYwbQmT71Frtw+6lJpmBZHr78KOQi66Zx5+SOg==",
+			"version": "9.2.6",
+			"resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-9.2.6.tgz",
+			"integrity": "sha512-1AEDs2AUqOWh7Wl4onOhXmQF+Rz1zNdPXF+Kxm4aWl92RQ42Sh2CmTvRt2BJku83VQ91KFIEm/v3qd3Urzf+Uw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -1997,9 +1971,9 @@
 			}
 		},
 		"node_modules/@luma.gl/gltf": {
-			"version": "9.2.5",
-			"resolved": "https://registry.npmjs.org/@luma.gl/gltf/-/gltf-9.2.5.tgz",
-			"integrity": "sha512-hQFwtgKK4Vnd6t2bqlKVX+Z+Q5gCimq3V9LCiQmQ6An3t4KbbcXltBaBajSzkL9YEaozszSbcOUaFDXkav8CeQ==",
+			"version": "9.2.6",
+			"resolved": "https://registry.npmjs.org/@luma.gl/gltf/-/gltf-9.2.6.tgz",
+			"integrity": "sha512-is3YkiGsWqWTmwldMz6PRaIUleufQfUKYjJTKpsF5RS1OnN+xdAO0mJq5qJTtOQpppWAU0VrmDFEVZ6R3qvm0A==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -2016,9 +1990,9 @@
 			}
 		},
 		"node_modules/@luma.gl/shadertools": {
-			"version": "9.2.5",
-			"resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-9.2.5.tgz",
-			"integrity": "sha512-9upnT6r5exwotM1atc7Nwa7P69MKx+FavXWlabjk+nrRjeIJwzQ/3sXg9UfdDLavN/cDwGvnWz05UlbyABMmJg==",
+			"version": "9.2.6",
+			"resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-9.2.6.tgz",
+			"integrity": "sha512-4+uUbynqPUra9d/z1nQChyHmhLgmKfSMjS7kOwLB6exSnhKnpHL3+Hu9fv55qyaX50nGH3oHawhGtJ6RRvu65w==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -2866,35 +2840,6 @@
 				"url": "https://opencollective.com/turf"
 			}
 		},
-		"node_modules/@turf/bbox/node_modules/@turf/helpers": {
-			"version": "7.3.2",
-			"resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.2.tgz",
-			"integrity": "sha512-5HFN42rgWjSobdTMxbuq+ZdXPcqp1IbMgFYULTLCplEQM3dXhsyRFe7DCss4Eiw12iW3q6Z5UeTNVfITsE5lgA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@types/geojson": "^7946.0.10",
-				"tslib": "^2.8.1"
-			},
-			"funding": {
-				"url": "https://opencollective.com/turf"
-			}
-		},
-		"node_modules/@turf/bbox/node_modules/@turf/meta": {
-			"version": "7.3.2",
-			"resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.2.tgz",
-			"integrity": "sha512-FIcIY+ZsAe9QV4fHciTXeuRz2TKIVaEjivkl4vMFCibdj7FUkWDofqOncbIre1xPrgktQeh20ZrmD+p0kf3n4Q==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@turf/helpers": "7.3.2",
-				"@types/geojson": "^7946.0.10",
-				"tslib": "^2.8.1"
-			},
-			"funding": {
-				"url": "https://opencollective.com/turf"
-			}
-		},
 		"node_modules/@turf/boolean-clockwise": {
 			"version": "5.1.5",
 			"resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
@@ -2922,20 +2867,6 @@
 			"dependencies": {
 				"@turf/bbox": "7.3.2",
 				"@turf/helpers": "7.3.2",
-				"@types/geojson": "^7946.0.10",
-				"tslib": "^2.8.1"
-			},
-			"funding": {
-				"url": "https://opencollective.com/turf"
-			}
-		},
-		"node_modules/@turf/center/node_modules/@turf/helpers": {
-			"version": "7.3.2",
-			"resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.2.tgz",
-			"integrity": "sha512-5HFN42rgWjSobdTMxbuq+ZdXPcqp1IbMgFYULTLCplEQM3dXhsyRFe7DCss4Eiw12iW3q6Z5UeTNVfITsE5lgA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
 				"@types/geojson": "^7946.0.10",
 				"tslib": "^2.8.1"
 			},
@@ -3190,17 +3121,17 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.53.0.tgz",
-			"integrity": "sha512-eEXsVvLPu8Z4PkFibtuFJLJOTAV/nPdgtSjkGoPpddpFk3/ym2oy97jynY6ic2m6+nc5M8SE1e9v/mHKsulcJg==",
+			"version": "8.56.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.0.tgz",
+			"integrity": "sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.53.0",
-				"@typescript-eslint/type-utils": "8.53.0",
-				"@typescript-eslint/utils": "8.53.0",
-				"@typescript-eslint/visitor-keys": "8.53.0",
+				"@typescript-eslint/scope-manager": "8.56.0",
+				"@typescript-eslint/type-utils": "8.56.0",
+				"@typescript-eslint/utils": "8.56.0",
+				"@typescript-eslint/visitor-keys": "8.56.0",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.4.0"
@@ -3213,22 +3144,22 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.53.0",
-				"eslint": "^8.57.0 || ^9.0.0",
+				"@typescript-eslint/parser": "^8.56.0",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.53.0.tgz",
-			"integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
+			"version": "8.56.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.0.tgz",
+			"integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.53.0",
-				"@typescript-eslint/types": "8.53.0",
-				"@typescript-eslint/typescript-estree": "8.53.0",
-				"@typescript-eslint/visitor-keys": "8.53.0",
+				"@typescript-eslint/scope-manager": "8.56.0",
+				"@typescript-eslint/types": "8.56.0",
+				"@typescript-eslint/typescript-estree": "8.56.0",
+				"@typescript-eslint/visitor-keys": "8.56.0",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -3239,19 +3170,19 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.53.0.tgz",
-			"integrity": "sha512-Bl6Gdr7NqkqIP5yP9z1JU///Nmes4Eose6L1HwpuVHwScgDPPuEWbUVhvlZmb8hy0vX9syLk5EGNL700WcBlbg==",
+			"version": "8.56.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.0.tgz",
+			"integrity": "sha512-M3rnyL1vIQOMeWxTWIW096/TtVP+8W3p/XnaFflhmcFp+U4zlxUxWj4XwNs6HbDeTtN4yun0GNTTDBw/SvufKg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.53.0",
-				"@typescript-eslint/types": "^8.53.0",
+				"@typescript-eslint/tsconfig-utils": "^8.56.0",
+				"@typescript-eslint/types": "^8.56.0",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -3266,14 +3197,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.53.0.tgz",
-			"integrity": "sha512-kWNj3l01eOGSdVBnfAF2K1BTh06WS0Yet6JUgb9Cmkqaz3Jlu0fdVUjj9UI8gPidBWSMqDIglmEXifSgDT/D0g==",
+			"version": "8.56.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.0.tgz",
+			"integrity": "sha512-7UiO/XwMHquH+ZzfVCfUNkIXlp/yQjjnlYUyYz7pfvlK3/EyyN6BK+emDmGNyQLBtLGaYrTAI6KOw8tFucWL2w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.53.0",
-				"@typescript-eslint/visitor-keys": "8.53.0"
+				"@typescript-eslint/types": "8.56.0",
+				"@typescript-eslint/visitor-keys": "8.56.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3284,9 +3215,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.53.0.tgz",
-			"integrity": "sha512-K6Sc0R5GIG6dNoPdOooQ+KtvT5KCKAvTcY8h2rIuul19vxH5OTQk7ArKkd4yTzkw66WnNY0kPPzzcmWA+XRmiA==",
+			"version": "8.56.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.0.tgz",
+			"integrity": "sha512-bSJoIIt4o3lKXD3xmDh9chZcjCz5Lk8xS7Rxn+6l5/pKrDpkCwtQNQQwZ2qRPk7TkUYhrq3WPIHXOXlbXP0itg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3301,15 +3232,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.53.0.tgz",
-			"integrity": "sha512-BBAUhlx7g4SmcLhn8cnbxoxtmS7hcq39xKCgiutL3oNx1TaIp+cny51s8ewnKMpVUKQUGb41RAUWZ9kxYdovuw==",
+			"version": "8.56.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.0.tgz",
+			"integrity": "sha512-qX2L3HWOU2nuDs6GzglBeuFXviDODreS58tLY/BALPC7iu3Fa+J7EOTwnX9PdNBxUI7Uh0ntP0YWGnxCkXzmfA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.53.0",
-				"@typescript-eslint/typescript-estree": "8.53.0",
-				"@typescript-eslint/utils": "8.53.0",
+				"@typescript-eslint/types": "8.56.0",
+				"@typescript-eslint/typescript-estree": "8.56.0",
+				"@typescript-eslint/utils": "8.56.0",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.4.0"
 			},
@@ -3321,14 +3252,14 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.53.0.tgz",
-			"integrity": "sha512-Bmh9KX31Vlxa13+PqPvt4RzKRN1XORYSLlAE+sO1i28NkisGbTtSLFVB3l7PWdHtR3E0mVMuC7JilWJ99m2HxQ==",
+			"version": "8.56.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.0.tgz",
+			"integrity": "sha512-DBsLPs3GsWhX5HylbP9HNG15U0bnwut55Lx12bHB9MpXxQ+R5GC8MwQe+N1UFXxAeQDvEsEDY6ZYwX03K7Z6HQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3340,16 +3271,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.53.0.tgz",
-			"integrity": "sha512-pw0c0Gdo7Z4xOG987u3nJ8akL9093yEEKv8QTJ+Bhkghj1xyj8cgPaavlr9rq8h7+s6plUJ4QJYw2gCZodqmGw==",
+			"version": "8.56.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.0.tgz",
+			"integrity": "sha512-ex1nTUMWrseMltXUHmR2GAQ4d+WjkZCT4f+4bVsps8QEdh0vlBsaCokKTPlnqBFqqGaxilDNJG7b8dolW2m43Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.53.0",
-				"@typescript-eslint/tsconfig-utils": "8.53.0",
-				"@typescript-eslint/types": "8.53.0",
-				"@typescript-eslint/visitor-keys": "8.53.0",
+				"@typescript-eslint/project-service": "8.56.0",
+				"@typescript-eslint/tsconfig-utils": "8.56.0",
+				"@typescript-eslint/types": "8.56.0",
+				"@typescript-eslint/visitor-keys": "8.56.0",
 				"debug": "^4.4.3",
 				"minimatch": "^9.0.5",
 				"semver": "^7.7.3",
@@ -3368,9 +3299,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -3381,16 +3312,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.53.0.tgz",
-			"integrity": "sha512-XDY4mXTez3Z1iRDI5mbRhH4DFSt46oaIFsLg+Zn97+sYrXACziXSQcSelMybnVZ5pa1P6xYkPr5cMJyunM1ZDA==",
+			"version": "8.56.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.0.tgz",
+			"integrity": "sha512-RZ3Qsmi2nFGsS+n+kjLAYDPVlrzf7UhTffrDIKr+h2yzAlYP/y5ZulU0yeDEPItos2Ph46JAL5P/On3pe7kDIQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.53.0",
-				"@typescript-eslint/types": "8.53.0",
-				"@typescript-eslint/typescript-estree": "8.53.0"
+				"@typescript-eslint/scope-manager": "8.56.0",
+				"@typescript-eslint/types": "8.56.0",
+				"@typescript-eslint/typescript-estree": "8.56.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3400,19 +3331,19 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.53.0.tgz",
-			"integrity": "sha512-LZ2NqIHFhvFwxG0qZeLL9DvdNAHPGCY5dIRwBhyYeU+LfLhcStE1ImjsuTG/WaVh3XysGaeLW8Rqq7cGkPCFvw==",
+			"version": "8.56.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.0.tgz",
+			"integrity": "sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.53.0",
-				"eslint-visitor-keys": "^4.2.1"
+				"@typescript-eslint/types": "8.56.0",
+				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3423,13 +3354,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.0.tgz",
+			"integrity": "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
@@ -3880,9 +3811,9 @@
 			}
 		},
 		"node_modules/ajv-formats/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -4236,14 +4167,14 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-			"integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+			"version": "1.13.5",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+			"integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"follow-redirects": "^1.15.6",
-				"form-data": "^4.0.4",
+				"follow-redirects": "^1.15.11",
+				"form-data": "^4.0.5",
 				"proxy-from-env": "^1.1.0"
 			}
 		},
@@ -6653,9 +6584,9 @@
 			}
 		},
 		"node_modules/geotiff": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.3.tgz",
-			"integrity": "sha512-PT6uoF5a1+kbC3tHmZSUsLHBp2QJlHasxxxxPW47QIY1VBKpFB+FcDvX+MxER6UzgLQZ0xDzJ9s48B9JbOCTqA==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/geotiff/-/geotiff-3.0.3.tgz",
+			"integrity": "sha512-yRoDQDYxWYiB421p0cbxJvdy79OlQW+rxDI9GDbIUeWCAh6YAZ0vlTKF448EAiEuuUpBsNaegd2flavF0p+kvw==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -6664,9 +6595,9 @@
 				"pako": "^2.0.4",
 				"parse-headers": "^2.0.2",
 				"quick-lru": "^6.1.1",
-				"web-worker": "^1.2.0",
-				"xml-utils": "^1.0.2",
-				"zstddec": "^0.1.0"
+				"web-worker": "^1.5.0",
+				"xml-utils": "^1.10.2",
+				"zstddec": "^0.2.0"
 			},
 			"engines": {
 				"node": ">=10.19"
@@ -7890,13 +7821,6 @@
 				"url": "https://github.com/sponsors/panva"
 			}
 		},
-		"node_modules/jpeg-js": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
-			"integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
-			"license": "BSD-3-Clause",
-			"peer": true
-		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8182,9 +8106,9 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"version": "4.17.23",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
 			"license": "MIT",
 			"peer": true
 		},
@@ -11167,9 +11091,9 @@
 			}
 		},
 		"node_modules/schema-utils/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -12697,16 +12621,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.53.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.53.0.tgz",
-			"integrity": "sha512-xHURCQNxZ1dsWn0sdOaOfCSQG0HKeqSj9OexIxrz6ypU6wHYOdX2I3D2b8s8wFSsSOYJb+6q283cLiLlkEsBYw==",
+			"version": "8.56.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.56.0.tgz",
+			"integrity": "sha512-c7toRLrotJ9oixgdW7liukZpsnq5CZ7PuKztubGYlNppuTqhIoWfhgHo/7EU0v06gS2l/x0i2NEFK1qMIf0rIg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.53.0",
-				"@typescript-eslint/parser": "8.53.0",
-				"@typescript-eslint/typescript-estree": "8.53.0",
-				"@typescript-eslint/utils": "8.53.0"
+				"@typescript-eslint/eslint-plugin": "8.56.0",
+				"@typescript-eslint/parser": "8.56.0",
+				"@typescript-eslint/typescript-estree": "8.56.0",
+				"@typescript-eslint/utils": "8.56.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -12716,7 +12640,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
@@ -13755,9 +13679,9 @@
 			"peer": true
 		},
 		"node_modules/zstddec": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
-			"integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.2.0.tgz",
+			"integrity": "sha512-oyPnDa1X5c13+Y7mA/FDMNJrn4S8UNBe0KCqtDmor40Re7ALrPN6npFwyYVRRh+PqozZQdeg23QtbcamZnG5rA==",
 			"license": "MIT AND BSD-3-Clause",
 			"peer": true
 		}

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
 		"@deck.gl/geo-layers": "^9.2.2",
 		"@deck.gl/layers": "^9.2.2",
 		"@deck.gl/react": "^9.2.2",
-		"@gisatcz/deckgl-geolib": "^2.0.0",
+		"@gisatcz/deckgl-geolib": "^2.1.1",
 		"@gisatcz/ptr-be-core": "^0.0.7",
 		"@mantine/core": "^8.0.2",
 		"@mantine/hooks": "^8.0.2",


### PR DESCRIPTION
This pull request makes a minor update to the project dependencies, specifically bumping the version of a mapping library to ensure compatibility and access to the latest features and fixes.

- Dependency update:
  * Upgraded `@gisatcz/deckgl-geolib` from version `2.0.0` to `2.1.1` in `package.json` to use the latest improvements and bug fixes.