### PR TITLE
fix: update GitHub Actions token creation and semantic-release config

### DIFF
--- a/.github/workflows/issues-sync.yml
+++ b/.github/workflows/issues-sync.yml
@@ -13,7 +13,7 @@ jobs:
       id: get_token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ secrets.NOTION_SYNC_APP_ID }}
+        client-id: ${{ secrets.NOTION_SYNC_APP_ID }}
         private-key: ${{ secrets.NOTION_SYNC_APP_KEY }}
 
     - name: Notion Sync Action

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,9 +1,19 @@
 {
-	"branches": ["main", "master", { "name": "dev", "prerelease": true, "channel": "dev" }, "rc"],
+	"branches": ["main", { "name": "dev", "prerelease": true, "channel": "dev" }],
 	"tagFormat": "v${version}",
 	"plugins": [
-		"@semantic-release/commit-analyzer",
-		"@semantic-release/release-notes-generator",
+		[
+			"@semantic-release/commit-analyzer",
+			{
+				"preset": "conventionalcommits"
+			}
+		],
+		[
+			"@semantic-release/release-notes-generator",
+			{
+				"preset": "conventionalcommits"
+			}
+		],
 		"@semantic-release/changelog",
 		"@semantic-release/npm",
 		"@semantic-release/github",


### PR DESCRIPTION
## Summary
- Fix GitHub Actions token creation: changed app-id to client-id in issues-sync.yml
- Update semantic-release config: removed master and rc branches, added conventionalcommits preset

## Problem
- GitHub App token action requires client-id parameter (not app-id)
- Release config needed explicit conventionalcommits preset and branch cleanup

## Changes
- .github/workflows/issues-sync.yml: app-id → client-id
- .releaserc.json: removed master/rc branches, added conventionalcommits presets