### PR TITLE
chore: update Notion issue sync schedule

### DIFF
--- a/.github/workflows/issues-sync.yml
+++ b/.github/workflows/issues-sync.yml
@@ -2,7 +2,7 @@ name: Sync GitHub Issues to Notion
 
 on:
   schedule:
-    - cron: '27 */8 * * *' # Every 8 hours at minute 14
+    - cron: '47 */4 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Updated Notion issue sync workflow schedule from every 8 hours to every 4 hours
- Used randomly generated minute (47) to reduce contention with other scheduled workflows

## Problem
- Previous schedule ran every 8 hours, which was less frequent than recommended
- Cron minute was hardcoded without following the random generation requirement

## Solution
- Changed cron schedule from `27 */8 * * *` to `47 */4 * * *`
- Generated random minute using `shuf -i 0-59 -n 1` as per Ainstruct document

## Changes
- .github/workflows/issues-sync.yml - Updated cron schedule and removed misleading comment